### PR TITLE
Generated en_UD.lang

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,10 @@ buildscript {
     }
 }
 
+plugins{
+	id "thefireplace.en2ud" version "0.9"
+}
+
 apply plugin: 'net.minecraftforge.gradle.forge'
 
 if (System.env.BUILD_NUMBER != null) {
@@ -30,6 +34,10 @@ minecraft {
     
     mappings = "snapshot_20171003"
     makeObfSourceJar = false
+}
+
+en2ud {
+	modid = "dakimakuramod"
 }
 
 dependencies {

--- a/src/main/resources/assets/dakimakuramod/lang/en_UD.lang
+++ b/src/main/resources/assets/dakimakuramod/lang/en_UD.lang
@@ -1,0 +1,55 @@
+
+tile.dakimakuramod:dakimakura.name=ɐɹnʞɐɯᴉʞɐᗡ
+
+tile.dakimakuramod:dakimakura.tooltip=¡puǝᴉɹɟ ǝꞁqɐᵷᵷnɥ Ɐ
+tile.dakimakuramod:dakimakura.tooltip.pack=§7(%2$d/%1$d) - §f%s§7 :ʞɔɐԀ§f
+tile.dakimakuramod:dakimakura.tooltip.name=§f%s§7 :ǝɯɐN§f
+tile.dakimakuramod:dakimakura.tooltip.flavour=§o%s§5§f
+tile.dakimakuramod:dakimakura.tooltip.flip=§7˙dᴉꞁɟ oʇ ɹᴉɐ ǝɥʇ uᴉ §aʞɔᴉꞁɔ ʇɥᵷᴉɹ§f puɐ ʞɐǝuS
+tile.dakimakuramod:dakimakura.tooltip.blank=ʞuɐꞁᗺ
+
+item.dakimakuramod:daki-design.name=uᵷᴉsǝᗡ ɐɹnʞɐɯᴉʞɐᗡ
+
+item.dakimakuramod:daki-design.tooltip.unlock=§7˙uᵷᴉsǝp ɐɹnʞɐɯᴉʞɐp ɐ ʞɔoꞁun oʇ ɯǝʇᴉ sᴉɥʇ §aʞɔᴉꞁɔ ʇɥᵷᴉᴚ§f
+item.dakimakuramod:daki-design.tooltip.usage=˙ɐɹnʞɐɯᴉʞɐp ʞuɐꞁq ɐ ɥʇᴉʍ uᵷᴉsǝp sᴉɥʇ ʇɟɐɹƆ
+
+itemGroup.dakimakuramod=poW ɐɹnʞɐɯᴉʞɐᗡ
+
+chat.dakimakuramod:updateAvailable=˙ǝꞁqɐꞁᴉɐʌɐ sᴉ %s ǝʇɐpdn poW ɐɹnʞɐɯᴉʞɐᗡ
+chat.dakimakuramod:updateDownload=[pɐoꞁuʍoᗡ]
+chat.dakimakuramod:updateDownloadRollover=˙ǝᵷɐd pɐoꞁuʍop ǝɥʇ uǝdo oʇ ʞɔᴉꞁƆ
+chat.dakimakuramod:invalidJar=˙sʇsodǝɹ poɯ ꞁɐᵷǝꞁꞁᴉ ʇnoqɐ ǝɹoɯ uɹɐǝꞁ oʇ %2$s ʞɔᴉꞁɔ ɹo ǝᵷɐd pɐoꞁuʍop ꞁɐᴉɔᴉɟɟo ǝɥʇ uǝdo oʇ %1$s ʞɔᴉꞁɔ ǝsɐǝꞁԀ ˙ǝꞁᴉɟ ɹɐɾ pᴉꞁɐʌuᴉ uɐ pǝʇɔǝʇǝp sɐɥ poW ɐɹnʞɐɯᴉʞɐᗡ
+chat.dakimakuramod:invalidJarDownload=[ǝɹǝɥ]
+chat.dakimakuramod:invalidJarDownloadTooltip=˙ǝᵷɐd pɐoꞁuʍop ǝɥʇ uǝdo oʇ ʞɔᴉꞁƆ
+chat.dakimakuramod:invalidJarStopModReposts=[ǝɹǝɥ]
+chat.dakimakuramod:invalidJarStopModRepostsTooltip=˙ǝᵷɐd sʇsodǝᴚ poW doʇS uǝdo oʇ ʞɔᴉꞁƆ
+
+config.dakimakuramod:enableRecipe=˙ǝdᴉɔǝɹ ᵷuᴉʇɟɐɹɔ ǝꞁqɐuƎ
+config.dakimakuramod:enableRecipe.tooltip=˙sɐɹnʞɐɯᴉʞɐp ɹoɟ ǝdᴉɔǝɹ ᵷuᴉʇɟɐɹɔ ǝɥʇ ǝꞁqɐuƎ
+
+config.dakimakuramod:useAltRecipe=˙ǝdᴉɔǝɹ ᵷuᴉʇɟɐɹɔ ǝʌᴉʇɐuɹǝʇꞁɐ ǝs∩
+config.dakimakuramod:useAltRecipe.tooltip=˙ᵷuᴉɹʇs 9 puɐ ꞁooʍ Ɛ oʇ ꞁooʍ 9 ɯoɹɟ ǝdᴉɔǝɹ ᵷuᴉʇɟɐɹɔ ǝɥʇ sǝᵷuɐɥƆ
+
+config.dakimakuramod:enableRecycleRecipe=˙ǝdᴉɔǝɹ ǝꞁɔʎɔǝɹ ǝꞁqɐuƎ
+config.dakimakuramod:enableRecycleRecipe.tooltip=˙ɹǝɥʇǝᵷoʇ suᵷᴉsǝp pǝʇuɐʍun ᘔ ᵷuᴉʇɟɐɹɔ ʎq uᵷᴉsǝp ɐɹnʞɐɯᴉʞɐp ʍǝu ɐ ᵷuᴉʇʇǝᵷ ʍoꞁꞁⱯ
+
+config.dakimakuramod:enableClearingRecipe=˙ǝdᴉɔǝɹ ᵷuᴉɹɐǝꞁɔ ǝꞁqɐuƎ
+config.dakimakuramod:enableClearingRecipe.tooltip=˙uᵷᴉsǝp sʇᴉ ɹɐǝꞁɔ oʇ ɐɹnʞɐɯᴉʞɐp ɐ ᵷuᴉʇɟɐɹɔ ʍoꞁꞁⱯ
+
+config.dakimakuramod:addUnlockToLootChests=˙sʇsǝɥɔ ʇooꞁ oʇ suᵷᴉsǝp ppⱯ
+config.dakimakuramod:addUnlockToLootChests.tooltip=˙pꞁɹoʍ ǝɥʇ punoɹɐ sʇsǝɥɔ ʇooꞁ oʇ sɯǝʇᴉ uᵷᴉsǝp ɐɹnʞɐɯᴉʞɐp ǝɥʇ ppⱯ
+
+config.dakimakuramod:mobDropChance=˙ǝɔuɐɥɔ doɹp poW
+config.dakimakuramod:mobDropChance.tooltip=˙sdoɹp qoɯ sǝꞁqɐsᴉp 0 ˙uᵷᴉsǝp ɐɹnʞɐɯᴉʞɐp ɐ ᵷuᴉddoɹp sqoɯ ɟo ǝɔuɐɥɔ ǝᵷɐʇuǝɔɹǝԀ
+
+config.dakimakuramod:mobDropLootingBonus=˙snuoq ᵷuᴉʇooꞁ doɹp qoW
+config.dakimakuramod:mobDropLootingBonus.tooltip=(ꞁǝʌǝꞀᵷuᴉʇooꞁ * snuoᗺᵷuᴉʇooꞀdoɹᗡqoɯ) + ǝɔuɐɥƆdoɹᗡqoɯ\n˙ᵷuᴉʇooꞁ ɟo ꞁǝʌǝꞁ ɥɔɐǝ ɹoɟ uᵷᴉsǝp ɐɹnʞɐɯᴉʞɐp ɐ ᵷuᴉddoɹp sqoɯ ɟo ǝɔuɐɥɔ ǝᵷɐʇuǝɔɹǝd snuoq ɐɹʇxƎ
+
+config.dakimakuramod:textureMaxSize=˙ǝzᴉs ǝɹnʇxǝʇ xɐW
+config.dakimakuramod:textureMaxSize.tooltip=˙ǝzᴉs ǝɹnʇxǝʇ xɐɯ s∩Ԁ⅁ ǝɥʇ ʇɐ pǝddɐɔ ǝq ꞁꞁᴉM\n˙ᘔ ɟo ɹǝʍod ʇsǝɹɐǝu ǝɥʇ oʇ dn pǝpunoɹ ǝq ꞁꞁᴉʍ sᴉɥ⟘\n˙sɐɹnʞɐɯᴉʞɐp ɹoɟ ǝzᴉs ǝɹnʇxǝʇ xɐW
+
+config.dakimakuramod:dakiRenderDist=˙ǝɔuɐʇsᴉp ɹǝpuǝɹ xɐW
+config.dakimakuramod:dakiRenderDist.tooltip=˙ɹǝpuǝɹ ꞁꞁᴉʍ sɐɹnʞɐɯᴉʞɐp sʞɔoꞁq uᴉ ʎɐʍɐ ǝɔuɐʇsᴉp ɯnɯᴉxɐɯ ǝɥ⟘
+
+config.dakimakuramod:checkForUpdates=¿sǝʇɐpdn ɹoɟ ʞɔǝɥƆ
+config.dakimakuramod:checkForUpdates.tooltip=¿suoᴉsɹǝʌ ɹǝʍǝu ɹoɟ ʞɔǝɥɔ poɯ ǝɥʇ pꞁnoɥS


### PR DESCRIPTION
I left [the tool](https://github.com/The-Fireplace/MC-en-UD-Generator) there so you can generate en_UD.lang again when you add new localizations.